### PR TITLE
Fixed Build Failure: Moved PropTypes out of react as separate package as no longer included

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, Text, FlatList, TouchableOpacity, Image } from 'react-native';
 import styles from './CategoryStyles';
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/TuNguyenThanh/react-native-category.git"
   },
   "dependencies": {
+    "prop-types": "^15.7.2",
     "react-native-vector-icons": "^4.0.1"
   },
   "keywords": [


### PR DESCRIPTION
Allows build as PropTypes is no longer included in react so need to import library instead.